### PR TITLE
has_primary_ip should equal true

### DIFF
--- a/netbox/netbox.go
+++ b/netbox/netbox.go
@@ -44,7 +44,7 @@ func (nb *Client) ListDevices(site, tag string) ([]Device, error) {
 	queryURL.Path = "/api/dcim/devices/"
 
 	queryVals := url.Values{}
-	queryVals.Add("has_primary_ip", "yes")
+	queryVals.Add("has_primary_ip", "true")
 
 	if tag != "" {
 		queryVals.Add("tag", tag)


### PR DESCRIPTION
Querying has_primary_ip requires the use of true/false.

If I use anything other than "true/false" when querying has_primary_ip, the filter is ultimately ignored. True/false works as expected. This was tested against netbox v3.5.7.